### PR TITLE
Fix shared renderer imports

### DIFF
--- a/packages/chat-ui/src/components/MessageList.tsx
+++ b/packages/chat-ui/src/components/MessageList.tsx
@@ -29,8 +29,8 @@ import {
   MessageFilters,
   DEFAULT_CHAT_CONFIG 
 } from '../types';
-import { UIComponentRenderer } from '@mcp/ui-renderer';
-import { isHtmlResourceBlock, UiActionEvent } from '@mcp/shared';
+import { UIComponentRenderer } from '@mcp-ui/ui-renderer';
+import { isHtmlResourceBlock, UiActionEvent } from '@mcp-ui/shared';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 // HACK: We might need to consider XSS implications more deeply if markdown allows arbitrary HTML.

--- a/packages/ui-renderer/src/UIComponentRenderer.tsx
+++ b/packages/ui-renderer/src/UIComponentRenderer.tsx
@@ -1,6 +1,6 @@
 // packages/ui-renderer/src/UIComponentRenderer.tsx
 import React, { useEffect, useRef } from 'react';
-import { HtmlResourceBlock, ResourceContentPayload, UiActionEvent, DEFAULTS as SHARED_DEFAULTS } from '@mcp/shared';
+import { HtmlResourceBlock, ResourceContentPayload, UiActionEvent, DEFAULTS as SHARED_DEFAULTS } from '@mcp-ui/shared';
 import { UIComponentRendererProps } from './types';
 
 const UIComponentRenderer: React.FC<UIComponentRendererProps> = ({

--- a/packages/ui-renderer/src/types.ts
+++ b/packages/ui-renderer/src/types.ts
@@ -1,5 +1,5 @@
 // packages/ui-renderer/src/types.ts
-import { HtmlResourceBlock, UiActionEvent } from '@mcp/shared'; // Assuming shared types
+import { HtmlResourceBlock, UiActionEvent } from '@mcp-ui/shared'; // Assuming shared types
 
 export interface UIComponentRendererProps {
   resource: HtmlResourceBlock;


### PR DESCRIPTION
## Summary
- update imports in MessageList to use new `@mcp-ui` scoped packages
- update ui-renderer imports to match new package scope

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint` *(fails: 53 errors)*
- `pnpm test` *(fails to run unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a07cb262c832f82c2addd52ac7518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to use new import paths for shared components and types. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->