### PR TITLE
Clean server-manager exports

### DIFF
--- a/packages/server-manager/src/__tests__/index.test.ts
+++ b/packages/server-manager/src/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { ServerManager, ServerRegistry } from '../index';
+
+describe('@mcp-ui/server-manager', () => {
+  it('exports ServerManager class', () => {
+    expect(ServerManager).toBeDefined();
+    const manager = new ServerManager();
+    expect(typeof manager.listServers).toBe('function');
+  });
+
+  it('exports ServerRegistry class', () => {
+    expect(ServerRegistry).toBeDefined();
+    const registry = new ServerRegistry();
+    expect(Array.isArray(registry.listServers())).toBe(true);
+  });
+});

--- a/packages/server-manager/src/index.ts
+++ b/packages/server-manager/src/index.ts
@@ -16,27 +16,12 @@
 // 📦 CORE EXPORTS
 export { ServerManager } from './manager/ServerManager';
 export { ServerRegistry } from './registry/ServerRegistry';
-export { ServerDiscovery } from './discovery/ServerDiscovery';
-export { ServerMonitor } from './monitor/ServerMonitor';
 export { default as ServerConfigForm } from './ui/ServerConfigForm'; // Added export
 
 // 🎯 TYPE EXPORTS
 // Replaced specific type exports with a wildcard export to include all types from './types'
 // This ensures ServerConfig, ServerStatus, and ServerTransportType are exported.
 export * from './types';
-
-// 🛠️ UTILITY EXPORTS
-export { createServerManager } from './utils/factory';
-export { validateServerConfig } from './utils/validation';
-export { ServerManagerError } from './utils/errors';
-
-// 🎨 CONSTANT EXPORTS
-export {
-  DEFAULT_MANAGER_CONFIG,
-  SERVER_DISCOVERY_METHODS,
-  HEALTH_CHECK_INTERVALS,
-  CONNECTION_POOL_LIMITS,
-} from './constants';
 
 /**
  * 🎓 ОБРАЗОВАТЕЛЬНАЯ ЗАМЕТКА - SERVER MANAGEMENT:
@@ -64,7 +49,4 @@ export {
 export default {
   ServerManager,
   ServerRegistry,
-  ServerDiscovery,
-  ServerMonitor,
-  createServerManager,
 };


### PR DESCRIPTION
## Summary
- clean up `server-manager` exports and default bundle
- add a basic test verifying `ServerManager` and registry exports

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0993f7a8832f858f153a092c4043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify the existence and basic functionality of key classes in the server manager package.

* **Refactor**
  * Streamlined and reduced the number of exports from the server manager package, consolidating type exports and removing several utility and constant exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->